### PR TITLE
Perf oriented updates

### DIFF
--- a/samples/Server/Components.fs
+++ b/samples/Server/Components.fs
@@ -16,7 +16,7 @@ module private TemplateDefinitions =
 
   let cardHeader = sh("x-card-header[slot=header]", Styles.CardHeader, h "slot")
 
-  let cardContent = sh("x-card-content", h "slot")
+  let cardContent = sh("x-card-content", empty, h "slot")
 
   let cardFooter = sh("x-card-footer[slot=footer]", Styles.CardFooter, h "slot")
 

--- a/samples/Server/Program.fs
+++ b/samples/Server/Program.fs
@@ -56,8 +56,8 @@ module Results =
 
 type Layout =
   static member inline Default(content: Node, ?head: Node, ?scripts: Node) =
-    let head = defaultArg head (Fragment [])
-    let scripts = defaultArg scripts (Fragment [])
+    let head = defaultArg head (empty)
+    let scripts = defaultArg scripts (empty)
 
     h(
       "html[lang=en].sl-theme-light",

--- a/src/Hox.Feliz/Library.fs
+++ b/src/Hox.Feliz/Library.fs
@@ -32,7 +32,7 @@ module Engine =
 
       AsyncNode tsk
 
-    member inline _.fragment(nodes: Node seq) = Fragment(nodes |> List.ofSeq)
+    member inline _.fragment(nodes: Node seq) = Fragment(LinkedList(nodes))
 
     member inline _.fragment(nodes: Node IAsyncEnumerable) = AsyncSeqNode nodes
 
@@ -92,7 +92,11 @@ module Engine =
 
 
   let H =
-    HtmlEngine((fun tag nodes -> h(tag, nodes)), Text, (fun () -> Fragment []))
+    HtmlEngine(
+      (fun tag nodes -> h(tag, nodes)),
+      Text,
+      (fun () -> Fragment(LinkedList()))
+    )
 
   let A =
     AttrEngine(

--- a/src/Hox/DSL.fs
+++ b/src/Hox/DSL.fs
@@ -520,6 +520,8 @@ type NodeDsl =
   static member inline fragment(nodes: IAsyncEnumerable<Node>) =
     AsyncSeqNode nodes
 
+  static member inline empty = Fragment(LinkedList())
+
   static member inline attribute(name: string, value: string) =
     Attribute { name = name; value = value }
 

--- a/src/Hox/DSL.fsi
+++ b/src/Hox/DSL.fsi
@@ -722,6 +722,12 @@ type NodeDsl =
   static member inline fragment: nodes: IAsyncEnumerable<Node> -> Node
 
   /// <summary>
+  /// Creates an empty node (shorthand for `fragment []`)
+  /// </summary>
+  /// <returns>A new node</returns>
+  static member inline empty: Node
+
+  /// <summary>
   /// Creates a new attribute node, this is meant to be added to nodes using the
   /// `NodeOps.addAttribute` function.
   /// </summary>

--- a/src/Hox/Node.fs
+++ b/src/Hox/Node.fs
@@ -17,12 +17,12 @@ type Node =
   | Text of text: string
   | Raw of raw: string
   | Comment of comment: string
-  | Fragment of nodes: Node list
+  | Fragment of nodes: Node LinkedList
   | AsyncNode of node: Node CancellableValueTask
   | AsyncSeqNode of nodes: Node IAsyncEnumerable
 
 and [<NoComparison; NoEquality>] Element = {
   tag: string
-  attributes: AttributeNode list
-  children: Node list
+  attributes: AttributeNode LinkedList
+  children: Node LinkedList
 }

--- a/src/Hox/Node.fsi
+++ b/src/Hox/Node.fsi
@@ -2,6 +2,7 @@ namespace Hox.Core
 
 open IcedTasks
 open System.Collections.Generic
+open System.Collections.Immutable
 
 
 /// This type is used to represent HTML attributes e.g `class="foo"`
@@ -26,7 +27,7 @@ type Node =
   | Text of text: string
   | Raw of raw: string
   | Comment of comment: string
-  | Fragment of nodes: Node list
+  | Fragment of nodes: Node LinkedList
   /// Async nodes require a cancellation token to be passed to them,
   /// As we'd like to be able to cancel the rendering process in case
   /// the user decides to cancel the operation.
@@ -34,12 +35,12 @@ type Node =
   | AsyncSeqNode of nodes: Node IAsyncEnumerable
 
 /// An element is a single HTML element e.g `<div></div>`
-/// It has a tag, a list of attributes and a list of children
-/// Since the children are nodes, any node can be added to this list
+/// It has a tag, a seq of attributes and a seq of children
+/// Since the children are nodes, any node can be added to this seq
 /// however that may lead to invalid HTML, so it's up to the user to make sure
 /// that the HTML is valid.
 and [<NoComparison; NoEquality>] Element = {
   tag: string
-  attributes: AttributeNode list
-  children: Node list
+  attributes: AttributeNode LinkedList
+  children: Node LinkedList
 }

--- a/src/Hox/Rendering.fs
+++ b/src/Hox/Rendering.fs
@@ -2,7 +2,7 @@ module Hox.Rendering
 
 open System
 open System.Collections.Generic
-open System.Diagnostics
+open System.Threading.Tasks
 
 open System.Web
 
@@ -12,7 +12,31 @@ open IcedTasks
 open Hox.Core
 open System.Threading
 
-let getAttributes(attributes: AttributeNode list) = cancellableValueTask {
+[<Struct; RequireQualifiedAccess>]
+type EscapeMode =
+  | Html
+  | Attribute
+
+let getEncodedCache escapeMode (encodedCache: Dictionary<string, string>) =
+  let cachedHtmlEncode(s: string) =
+    match encodedCache.TryGetValue(s) with
+    | true, encoded -> encoded
+    | false, _ ->
+      let encoded =
+        match escapeMode with
+        | EscapeMode.Html -> HttpUtility.HtmlEncode(s)
+        | EscapeMode.Attribute -> HttpUtility.HtmlAttributeEncode(s)
+
+      encodedCache.[s] <- encoded
+      encoded
+
+  cachedHtmlEncode
+
+
+let getAttributes(attributes: AttributeNode LinkedList) = cancellableValueTask {
+  let cachedHtmlEncode =
+    getEncodedCache EscapeMode.Attribute (Dictionary<string, string>())
+
   let clsSeq = ResizeArray()
   let attrSeq = ResizeArray()
   let mutable id = ValueNone
@@ -20,17 +44,15 @@ let getAttributes(attributes: AttributeNode list) = cancellableValueTask {
   // ids and classes have to be HtmlAttributeEncode'ed because we're
   // handling them separately, attributes are handled by the renderAttr function
   // which will HtmlAttributeEncode them.
-  for attribute in attributes do
-    match attribute with
-    | AttributeNode.Attribute { name = ""; value = value } -> ()
+  let mutable node = attributes.First
+
+  while node <> null do
+    match node.Value with
+    | AttributeNode.Attribute { name = ""; value = _ } -> ()
     | AttributeNode.Attribute { name = "class"; value = value } ->
-      clsSeq.Add(value |> HttpUtility.HtmlAttributeEncode)
+      clsSeq.Add(value |> cachedHtmlEncode)
     | AttributeNode.Attribute { name = "id"; value = value } ->
-      id <-
-        id
-        |> ValueOption.orElse(
-          ValueSome(value |> HttpUtility.HtmlAttributeEncode)
-        )
+      id <- id |> ValueOption.orElse(ValueSome(value |> cachedHtmlEncode))
     | AttributeNode.Attribute attribute -> attrSeq.Add(attribute)
     | AttributeNode.AsyncAttribute asyncAttribute ->
       let! { name = name; value = value } = asyncAttribute
@@ -38,41 +60,71 @@ let getAttributes(attributes: AttributeNode list) = cancellableValueTask {
       if name = String.Empty then
         ()
       elif name = "id" then
-        id <-
-          id
-          |> ValueOption.orElse(
-            ValueSome(value |> HttpUtility.HtmlAttributeEncode)
-          )
+        id <- id |> ValueOption.orElse(ValueSome(value |> cachedHtmlEncode))
       elif name = "class" then
-        clsSeq.Add(value |> HttpUtility.HtmlAttributeEncode)
+        clsSeq.Add(value |> cachedHtmlEncode)
       else
         attrSeq.Add({ name = name; value = value })
+
+    node <- node.Next
 
   return id, clsSeq, attrSeq
 }
 
 let renderAttr(node: AttributeNode) = cancellableValueTask {
+
   match node with
   | AttributeNode.Attribute { name = name; value = value } ->
-    return
-      $" %s{HttpUtility.HtmlAttributeEncode name}=\"%s{HttpUtility.HtmlAttributeEncode value}\""
+    return $" %s{name}=\"%s{value}\""
   | AsyncAttribute asyncAttribute ->
     let! { name = name; value = value } = asyncAttribute
 
     if name = String.Empty then
       return String.Empty
     else
-      return
-        $" %s{HttpUtility.HtmlAttributeEncode name}=\"%s{HttpUtility.HtmlAttributeEncode value}\""
+      return $" %s{name}=\"%s{value}\""
 }
+
+let voidTags =
+  lazy
+    (HashSet<string>(
+      [
+        "area"
+        "base"
+        "br"
+        "col"
+        "command"
+        "embed"
+        "hr"
+        "img"
+        "input"
+        "keygen"
+        "link"
+        "meta"
+        "param"
+        "source"
+        "track"
+        "wbr"
+      ],
+      StringComparer.OrdinalIgnoreCase
+    ))
 
 /// This module contains functions that are used to render a node to a string
 /// It is backed by a StringBuilder.
 module Builder =
   open System.Text
 
+
+
   let renderNode(node: Node) : CancellableValueTask<string> = cancellableValueTask {
     let! token = CancellableValueTask.getCancellationToken()
+
+    let cachedAttrEncode =
+      getEncodedCache EscapeMode.Attribute (Dictionary<string, string>())
+
+    let cachedHtmlEncode =
+      getEncodedCache EscapeMode.Html (Dictionary<string, string>())
+
     let sb = StringBuilder()
     let stack = Stack<struct (Node * bool)>()
     stack.Push(node, false)
@@ -91,7 +143,7 @@ module Builder =
         let! id, classes, attributes = getAttributes element.attributes
 
         match id with
-        | ValueSome id -> sb.Append($" id=\"%s{id}\"") |> ignore
+        | ValueSome id -> sb.Append(" id=\"").Append(id).Append("\"") |> ignore
         | ValueNone -> ()
 
         match classes with
@@ -99,45 +151,43 @@ module Builder =
         | classes ->
           sb.Append(" class=\"").AppendJoin(' ', classes).Append("\"") |> ignore
 
-        for attribute in attributes do
-          let! attribute = renderAttr(AttributeNode.Attribute attribute)
-          sb.Append(attribute) |> ignore
+        let operations =
+          attributes
+          |> Seq.map(fun ha -> async {
+            return!
+              renderAttr(
+                AttributeNode.Attribute {
+                  ha with
+                      value = cachedAttrEncode ha.value
+                      name = cachedAttrEncode ha.name
+                }
+              )
+          })
+
+        let! rendered = Async.Parallel operations
+        sb.AppendJoin(' ', rendered) |> ignore
 
         sb.Append(">") |> ignore
 
-        match element.tag.ToLowerInvariant() with
-        | "area"
-        | "base"
-        | "br"
-        | "col"
-        | "command"
-        | "embed"
-        | "hr"
-        | "img"
-        | "input"
-        | "keygen"
-        | "link"
-        | "meta"
-        | "param"
-        | "source"
-        | "track"
-        | "wbr" -> ()
-        | _ ->
+        if not(voidTags.Value.Contains(element.tag)) then
           stack.Push(Element element, true)
+          let mutable node = element.children.Last
 
-          if element.children.Length > 0 then
-            for child in element.children.Length - 1 .. -1 .. 0 do
-              stack.Push((element.children[child], false))
+          while node <> null do
+            stack.Push(node.Value, false)
+            node <- node.Previous
 
-      | Text text -> sb.Append(HttpUtility.HtmlEncode text) |> ignore
+      | Text text -> sb.Append(cachedHtmlEncode text) |> ignore
       | Raw raw -> sb.Append(raw) |> ignore
       | Comment comment ->
-        sb.Append($"<!--%s{HttpUtility.HtmlEncode comment}-->") |> ignore
+        sb.Append("<!--").Append(cachedHtmlEncode comment).Append("-->")
+        |> ignore
       | Fragment nodes ->
-        if nodes.Length > 0 then
-          for child in nodes.Length - 1 .. -1 .. 0 do
-            stack.Push((nodes[child], false))
+        let mutable node = nodes.Last
 
+        while node <> null do
+          stack.Push(node.Value, false)
+          node <- node.Previous
       | AsyncNode node ->
         // These nodes are already handling cancellation semantics
         // when they're added to the parent node, so we don't need to
@@ -147,12 +197,10 @@ module Builder =
       | AsyncSeqNode nodes ->
         // This is a complicated case, we need to handle cancellation
         // but TaskSeq.toListAsync doesn't support cancellation
-        let! nodes = nodes |> TaskSeq.toListAsync
+        let! nodes = nodes |> TaskSeq.toArrayAsync
 
         if nodes.Length > 0 then
-          for child in nodes.Length - 1 .. -1 .. 0 do
-            token.ThrowIfCancellationRequested()
-
+          for child = nodes.Length - 1 downto 0 do
             stack.Push((nodes[child], false))
 
     return sb.ToString()
@@ -182,6 +230,12 @@ module Chunked =
       cancellationToken: CancellationToken
     ) : IAsyncEnumerable<string> =
     taskSeq {
+      let cachedHtmlEncode =
+        getEncodedCache EscapeMode.Html (Dictionary<string, string>())
+
+      let cachedAttrEncode =
+        getEncodedCache EscapeMode.Attribute (Dictionary<string, string>())
+
       while stack.Count > 0 do
         cancellationToken.ThrowIfCancellationRequested()
 
@@ -208,44 +262,39 @@ module Chunked =
 
           for attribute in attributes do
             let! attribute =
-              renderAttr (AttributeNode.Attribute attribute) cancellationToken
+              renderAttr
+                (AttributeNode.Attribute {
+                  attribute with
+                      value = cachedAttrEncode attribute.value
+                      name = cachedAttrEncode attribute.name
+                })
+                cancellationToken
 
             attribute
 
           ">"
 
-          match element.tag with
-          | "area"
-          | "base"
-          | "br"
-          | "col"
-          | "command"
-          | "embed"
-          | "hr"
-          | "img"
-          | "input"
-          | "keygen"
-          | "link"
-          | "meta"
-          | "param"
-          | "source"
-          | "track"
-          | "wbr" -> ()
-          | _ ->
+          // Only non-void tags have children
+          // if the element is not a void tag also close it
+          if not(voidTags.Value.Contains(element.tag)) then
             stack.Push(Element element, true, depth)
 
-            if element.children.Length > 0 then
-              for child in element.children.Length - 1 .. -1 .. 0 do
-                stack.Push((element.children[child], false, depth + 1))
+            let mutable node = element.children.Last
 
-        | Text text -> HttpUtility.HtmlEncode text
+            while node <> null do
+              stack.Push(node.Value, false, depth)
+              node <- node.Previous
+
+        | Text text -> cachedHtmlEncode text
         | Raw raw -> raw
-        | Comment comment -> $"<!--%s{HttpUtility.HtmlEncode comment}-->"
+        | Comment comment -> $"<!--%s{cachedHtmlEncode comment}-->"
         | Fragment nodes ->
-          if nodes.Length > 0 then
-            for child in nodes.Length - 1 .. -1 .. 0 do
-              stack.Push((nodes[child], false, depth))
 
+          let mutable node = nodes.Last
+
+          while node <> null do
+            stack.Push(node.Value, false, depth)
+            node <- node.Previous
         | AsyncNode node ->
           // These nodes are already handling cancellation semantics
           // when they're added to the parent node, so we don't need to
@@ -261,13 +310,11 @@ module Chunked =
             // Similarly to the Builder module, we can't cancell this operation
             // as it doesn't support cancellation, so we'll just have to wait
             // for it to finish.
-            let! nodes = nodes |> TaskSeq.toListAsync
+            let! nodes = nodes |> TaskSeq.toArrayAsync
 
             if nodes.Length > 0 then
-              for child in nodes.Length - 1 .. -1 .. 0 do
-                cancellationToken.ThrowIfCancellationRequested()
-
-                stack.Push((nodes[child], false, depth))
+              for child = nodes.Length - 1 downto 0 do
+                stack.Push(nodes[child], false, depth)
 
           else
             // This part makes me a bit sad, since we can't reverse the sequence
@@ -283,18 +330,16 @@ module Chunked =
             // that or we could use async computations to attempt a recursive solution
             // but that would potentially make ValueTasks Hot which we'd like to avoid untill
             // we know the ValueTask is actually an async operation (see the cases above).
-            let items = ResizeArray()
+            let items = LinkedList()
 
             for node in nodes do
-              items.Add node
+              items.AddFirst(node) |> ignore
 
-            for i in items.Count - 1 .. -1 .. 0 do
-              cancellationToken.ThrowIfCancellationRequested()
-              stack.Push((items.[i], false, depth))
+            for item in items do
+              stack.Push(item, false, depth)
             // The next renderNode call will check it's own
             // cancellation token and throw if needed.
             yield! renderNode(stack, cancellationToken)
-
     }
 
 type Render =

--- a/src/Hox/Rendering.fs
+++ b/src/Hox/Rendering.fs
@@ -17,7 +17,10 @@ type EscapeMode =
   | Html
   | Attribute
 
-let getEncodedCache escapeMode (encodedCache: Dictionary<string, string>) =
+let inline getEncodedCache
+  escapeMode
+  (encodedCache: Dictionary<string, string>)
+  =
   let cachedHtmlEncode(s: string) =
     match encodedCache.TryGetValue(s) with
     | true, encoded -> encoded
@@ -96,7 +99,7 @@ let renderAttr(node: AttributeNode) = cancellableValueTask {
 
 let voidTags =
   lazy
-    (HashSet<string>(
+    (HashSet(
       [
         "area"
         "base"

--- a/src/Hox/SelectorParser.fs
+++ b/src/Hox/SelectorParser.fs
@@ -6,6 +6,7 @@ open System.Collections.Immutable
 open FParsec
 
 open Hox.Core
+open System.Collections.Generic
 
 [<Struct>]
 type private SelectorValue =
@@ -95,13 +96,16 @@ let private pSelector: Parser<Element, unit> =
           dcBuilder.Add(attribute.name, AttributeNode.Attribute attribute)
         | _, _ -> ()
 
+    let built = dcBuilder.ToImmutableArray()
+    let items = LinkedList()
+
+    for pair in built do
+      items.AddLast(pair.Value) |> ignore
+
     preturn {
       tag = tag
-      attributes =
-        dcBuilder.ToImmutableList()
-        |> Seq.map(fun pair -> pair.Value)
-        |> Seq.toList
-      children = []
+      attributes = items
+      children = LinkedList()
     }
 
 let selector(selector: string) =

--- a/tests/Hox.Tests/ChunkRender.fs
+++ b/tests/Hox.Tests/ChunkRender.fs
@@ -9,6 +9,7 @@ open IcedTasks
 
 open Hox.Rendering
 open Hox.Core
+open System.Collections.Generic
 
 [<Fact>]
 let ``Render can render an element``() = taskUnit {
@@ -19,8 +20,8 @@ let ``Render can render an element``() = taskUnit {
     Render.start(
       Element {
         tag = "div"
-        attributes = []
-        children = []
+        attributes = LinkedList()
+        children = LinkedList()
       }
     ) do
     actual.Add(chunk)
@@ -40,8 +41,8 @@ let ``Render can render an element with attributes``() = taskUnit {
     Render.start(
       Element {
         tag = "div"
-        attributes = [ Attribute { name = "class"; value = "foo" } ]
-        children = []
+        attributes = LinkedList([ Attribute { name = "class"; value = "foo" } ])
+        children = LinkedList()
       }
     ) do
     actual.Add(chunk)
@@ -61,14 +62,17 @@ let ``Render can render an element with children``() = taskUnit {
     Render.start(
       Element {
         tag = "div"
-        attributes = []
-        children = [
-          Element {
-            tag = "span"
-            attributes = []
-            children = []
-          }
-        ]
+        attributes = LinkedList()
+        children =
+          LinkedList(
+            [
+              Element {
+                tag = "span"
+                attributes = LinkedList()
+                children = LinkedList()
+              }
+            ]
+          )
       }
     ) do
     actual.Add(chunk)
@@ -88,14 +92,17 @@ let ``Render can render an element with children and attributes``() = taskUnit {
     Render.start(
       Element {
         tag = "div"
-        attributes = [ Attribute { name = "class"; value = "foo" } ]
-        children = [
-          Element {
-            tag = "span"
-            attributes = []
-            children = []
-          }
-        ]
+        attributes = LinkedList([ Attribute { name = "class"; value = "foo" } ])
+        children =
+          LinkedList(
+            [
+              Element {
+                tag = "span"
+                attributes = LinkedList()
+                children = LinkedList()
+              }
+            ]
+          )
       }
     ) do
     actual.Add(chunk)
@@ -125,14 +132,17 @@ let ``Render can render an element with children and attributes and text``() = t
     Render.start(
       Element {
         tag = "div"
-        attributes = [ Attribute { name = "class"; value = "foo" } ]
-        children = [
-          Element {
-            tag = "span"
-            attributes = []
-            children = [ Text "Hello" ]
-          }
-        ]
+        attributes = LinkedList([ Attribute { name = "class"; value = "foo" } ])
+        children =
+          LinkedList(
+            [
+              Element {
+                tag = "span"
+                attributes = LinkedList()
+                children = LinkedList([ Text "Hello" ])
+              }
+            ]
+          )
       }
     ) do
     actual.Add(chunk)
@@ -166,21 +176,28 @@ let ``Render can render an element with children and attributes and text and a f
       Render.start(
         Element {
           tag = "div"
-          attributes = [ Attribute { name = "class"; value = "foo" } ]
-          children = [
-            Element {
-              tag = "span"
-              attributes = []
-              children = [ Text "Hello" ]
-            }
-            Fragment [
+          attributes =
+            LinkedList([ Attribute { name = "class"; value = "foo" } ])
+          children =
+            LinkedList [
               Element {
                 tag = "span"
-                attributes = []
-                children = [ Text "World" ]
+                attributes = LinkedList()
+                children = LinkedList [ Text "Hello" ]
               }
+
+              Fragment(
+                LinkedList(
+                  [
+                    Element {
+                      tag = "span"
+                      attributes = LinkedList()
+                      children = LinkedList [ Text "World" ]
+                    }
+                  ]
+                )
+              )
             ]
-          ]
         }
       ) do
       actual.Add(chunk)
@@ -214,26 +231,28 @@ let ``Render can render an element with async nodes and async attributes``() = t
     Render.start(
       Element {
         tag = "div"
-        attributes = [
-          AsyncAttribute(
-            cancellableValueTask { return { name = "class"; value = "foo" } }
-          )
-          AsyncAttribute(
-            cancellableValueTask { return { name = "class"; value = "fa" } }
-          )
-        ]
-        children = [
-          AsyncNode(
-            cancellableValueTask {
-              return
-                Element {
-                  tag = "span"
-                  attributes = []
-                  children = []
-                }
-            }
-          )
-        ]
+        attributes =
+          LinkedList [
+            AsyncAttribute(
+              cancellableValueTask { return { name = "class"; value = "foo" } }
+            )
+            AsyncAttribute(
+              cancellableValueTask { return { name = "class"; value = "fa" } }
+            )
+          ]
+        children =
+          LinkedList [
+            AsyncNode(
+              cancellableValueTask {
+                return
+                  Element {
+                    tag = "span"
+                    attributes = LinkedList()
+                    children = LinkedList()
+                  }
+              }
+            )
+          ]
       }
     ) do
     actual.Add(chunk)
@@ -261,16 +280,17 @@ let ``Render can respect id, class, attribute order``() = taskUnit {
     Render.start(
       Element {
         tag = "div"
-        attributes = [
-          Attribute { name = "id"; value = "foo" }
-          Attribute { name = "class"; value = "bar" }
-          Attribute { name = "class"; value = "baz" }
-          Attribute { name = "class"; value = "qux" }
-          Attribute { name = "class"; value = "quux" }
-          Attribute { name = "data-foo"; value = "bar" }
-          Attribute { name = "data-bar"; value = "baz" }
-        ]
-        children = []
+        attributes =
+          LinkedList [
+            Attribute { name = "id"; value = "foo" }
+            Attribute { name = "class"; value = "bar" }
+            Attribute { name = "class"; value = "baz" }
+            Attribute { name = "class"; value = "qux" }
+            Attribute { name = "class"; value = "quux" }
+            Attribute { name = "data-foo"; value = "bar" }
+            Attribute { name = "data-bar"; value = "baz" }
+          ]
+        children = LinkedList()
       }
     ) do
     actual.Add(chunk)
@@ -303,45 +323,51 @@ let ``Render can render an element with children and attributes and text and a f
       Render.start(
         Element {
           tag = "div"
-          attributes = [
-            Attribute { name = "id"; value = "foo" }
-            Attribute { name = "class"; value = "bar" }
-            Attribute { name = "class"; value = "baz" }
-            Attribute { name = "class"; value = "qux" }
-            Attribute { name = "class"; value = "quux" }
-            Attribute { name = "data-foo"; value = "bar" }
-            Attribute { name = "data-bar"; value = "baz" }
-            AsyncAttribute(
-              cancellableValueTask { return { name = "class"; value = "foo" } }
-            )
-            AsyncAttribute(
-              cancellableValueTask { return { name = "class"; value = "fa" } }
-            )
-          ]
-          children = [
-            Element {
-              tag = "span"
-              attributes = []
-              children = [ Text "Hello" ]
-            }
-            Fragment [
+          attributes =
+            LinkedList [
+              Attribute { name = "id"; value = "foo" }
+              Attribute { name = "class"; value = "bar" }
+              Attribute { name = "class"; value = "baz" }
+              Attribute { name = "class"; value = "qux" }
+              Attribute { name = "class"; value = "quux" }
+              Attribute { name = "data-foo"; value = "bar" }
+              Attribute { name = "data-bar"; value = "baz" }
+              AsyncAttribute(
+                cancellableValueTask {
+                  return { name = "class"; value = "foo" }
+                }
+              )
+              AsyncAttribute(
+                cancellableValueTask { return { name = "class"; value = "fa" } }
+              )
+            ]
+          children =
+            LinkedList [
               Element {
                 tag = "span"
-                attributes = []
-                children = [ Text "World" ]
+                attributes = LinkedList()
+                children = LinkedList [ Text "Hello" ]
               }
-            ]
-            AsyncNode(
-              cancellableValueTask {
-                return
+              Fragment(
+                LinkedList [
                   Element {
                     tag = "span"
-                    attributes = []
-                    children = [ Text "Hello" ]
+                    attributes = LinkedList()
+                    children = LinkedList [ Text "World" ]
                   }
-              }
-            )
-          ]
+                ]
+              )
+              AsyncNode(
+                cancellableValueTask {
+                  return
+                    Element {
+                      tag = "span"
+                      attributes = LinkedList()
+                      children = LinkedList [ Text "Hello" ]
+                    }
+                }
+              )
+            ]
         }
       ) do
       actual.Add(chunk)
@@ -382,11 +408,12 @@ let ``Render discards any "id" attribute after the first``() = taskUnit {
     Render.start(
       Element {
         tag = "div"
-        attributes = [
-          Attribute { name = "id"; value = "foo" }
-          Attribute { name = "id"; value = "bar" }
-        ]
-        children = []
+        attributes =
+          LinkedList [
+            Attribute { name = "id"; value = "foo" }
+            Attribute { name = "id"; value = "bar" }
+          ]
+        children = LinkedList()
       }
     ) do
     actual.Add(chunk)
@@ -404,13 +431,14 @@ let ``Render discards any async "id" after the first``() = taskUnit {
     Render.start(
       Element {
         tag = "div"
-        attributes = [
-          Attribute { name = "id"; value = "foo" }
-          AsyncAttribute(
-            cancellableValueTask { return { name = "id"; value = "bar" } }
-          )
-        ]
-        children = []
+        attributes =
+          LinkedList [
+            Attribute { name = "id"; value = "foo" }
+            AsyncAttribute(
+              cancellableValueTask { return { name = "id"; value = "bar" } }
+            )
+          ]
+        children = LinkedList()
       }
     ) do
     actual.Add(chunk)
@@ -428,13 +456,14 @@ let ``Render discards any "id" after the first async attribute``() = taskUnit {
     Render.start(
       Element {
         tag = "div"
-        attributes = [
-          AsyncAttribute(
-            cancellableValueTask { return { name = "id"; value = "foo" } }
-          )
-          Attribute { name = "id"; value = "bar" }
-        ]
-        children = []
+        attributes =
+          LinkedList [
+            AsyncAttribute(
+              cancellableValueTask { return { name = "id"; value = "foo" } }
+            )
+            Attribute { name = "id"; value = "bar" }
+          ]
+        children = LinkedList()
       }
     ) do
     actual.Add(chunk)
@@ -496,7 +525,8 @@ let ``Render can render a comment node``() = taskUnit {
 let ``Render can render a fragment node``() = taskUnit {
   let actual = ResizeArray()
 
-  for chunk in Render.start(Fragment [ Text "Hello, "; Text "world!" ]) do
+  for chunk in
+    Render.start(Fragment(LinkedList [ Text "Hello, "; Text "world!" ])) do
     actual.Add(chunk)
 
   let expected = [ "Hello, "; "world!" ]
@@ -559,7 +589,7 @@ let ``Render can render an Async Seq Node with a fragment``() = taskUnit {
           do! Task.Delay(5)
           Text "world!"
           do! Task.Delay(5)
-          Fragment [ Text "Hello, "; Text "world!" ]
+          Fragment(LinkedList [ Text "Hello, "; Text "world!" ])
         }
       )
     ) do
@@ -587,7 +617,7 @@ let ``Render can render an Async Seq Node with a fragment and an async node``
             do! Task.Delay(5)
             Text "world!"
             do! Task.Delay(5)
-            Fragment [ Text "Hello, "; Text "world!" ]
+            Fragment(LinkedList [ Text "Hello, "; Text "world!" ])
             do! Task.Delay(5)
 
             AsyncNode(
@@ -613,15 +643,18 @@ let ``Render can render a mix of sync/async nodes``() = taskUnit {
 
   for chunk in
     Render.start(
-      Fragment [
-        Text "Hello, "
-        AsyncNode(
-          cancellableValueTask {
-            do! Task.Delay(5)
-            return Text "world!"
-          }
-        )
-      ]
+      Fragment(
+        LinkedList [
+          Text "Hello, "
+
+          AsyncNode(
+            cancellableValueTask {
+              do! Task.Delay(5)
+              return Text "world!"
+            }
+          )
+        ]
+      )
     ) do
     actual.Add(chunk)
 
@@ -636,16 +669,18 @@ let ``Render can render a mix of sync/async nodes with a fragment``() = taskUnit
 
   for chunk in
     Render.start(
-      Fragment [
-        Text "Hello, "
-        AsyncNode(
-          cancellableValueTask {
-            do! Task.Delay(5)
-            return Text "world!"
-          }
-        )
-        Fragment [ Text "Hello, "; Text "world!" ]
-      ]
+      Fragment(
+        LinkedList [
+          Text "Hello, "
+          AsyncNode(
+            cancellableValueTask {
+              do! Task.Delay(5)
+              return Text "world!"
+            }
+          )
+          Fragment(LinkedList [ Text "Hello, "; Text "world!" ])
+        ]
+      )
     ) do
     actual.Add(chunk)
 
@@ -663,34 +698,38 @@ let ``Render can render a mix of sync/async nodes with a mix of sync/async attri
 
     for chunk in
       Render.start(
-        Fragment [
-          AsyncNode(
-            cancellableValueTask {
-              do! Task.Delay(5)
-              return Text "Hello, "
+        Fragment(
+          LinkedList [
+            AsyncNode(
+              cancellableValueTask {
+                do! Task.Delay(5)
+                return Text "Hello, "
+              }
+            )
+            Element {
+              tag = "div"
+              attributes =
+                LinkedList [
+                  Attribute { name = "class"; value = "foo" }
+                  AsyncAttribute(
+                    cancellableValueTask {
+                      do! Task.Delay(5)
+                      return { name = "id"; value = "bar" }
+                    }
+                  )
+                ]
+              children =
+                LinkedList [
+                  AsyncNode(
+                    cancellableValueTask {
+                      do! Task.Delay(5)
+                      return Text "world!"
+                    }
+                  )
+                ]
             }
-          )
-          Element {
-            tag = "div"
-            attributes = [
-              Attribute { name = "class"; value = "foo" }
-              AsyncAttribute(
-                cancellableValueTask {
-                  do! Task.Delay(5)
-                  return { name = "id"; value = "bar" }
-                }
-              )
-            ]
-            children = [
-              AsyncNode(
-                cancellableValueTask {
-                  do! Task.Delay(5)
-                  return Text "world!"
-                }
-              )
-            ]
-          }
-        ]
+          ]
+        )
       ) do
       actual.Add(chunk)
 

--- a/tests/Hox.Tests/RenderAsyncString.fs
+++ b/tests/Hox.Tests/RenderAsyncString.fs
@@ -1,6 +1,8 @@
 module RenderAsyncString
 
 open System
+open System.Collections.Generic
+open System.Threading
 open Xunit
 
 open IcedTasks
@@ -9,15 +11,14 @@ open Hox.Core
 open Hox.Rendering
 open System.Threading.Tasks
 open FSharp.Control
-open System.Threading
 
 [<Fact>]
 let ``It should render an element``() = taskUnit {
   let node =
     Element {
       tag = "div"
-      attributes = []
-      children = []
+      attributes = LinkedList()
+      children = LinkedList()
     }
 
   let expected = "<div></div>"
@@ -32,8 +33,8 @@ let ``It should render an element with Async``() =
     let node =
       Element {
         tag = "div"
-        attributes = []
-        children = []
+        attributes = LinkedList()
+        children = LinkedList()
       }
 
     let expected = "<div></div>"
@@ -86,7 +87,7 @@ let ``It should render a comment node``() = taskUnit {
 
 [<Fact>]
 let ``It should render a fragment node``() = taskUnit {
-  let node = Fragment [ Text "Hello, "; Text "world!" ]
+  let node = Fragment(LinkedList [ Text "Hello, "; Text "world!" ])
 
   let expected = "Hello, world!"
 
@@ -125,11 +126,12 @@ let ``It should render an element with attributes``() = taskUnit {
   let node =
     Element {
       tag = "div"
-      attributes = [
-        Attribute { name = "class"; value = "foo" }
-        Attribute { name = "id"; value = "bar" }
-      ]
-      children = []
+      attributes =
+        LinkedList [
+          Attribute { name = "class"; value = "foo" }
+          Attribute { name = "id"; value = "bar" }
+        ]
+      children = LinkedList()
     }
 
   let expected = "<div id=\"bar\" class=\"foo\"></div>"
@@ -143,15 +145,16 @@ let ``It should render an element with an async attribute``() = taskUnit {
   let node =
     Element {
       tag = "div"
-      attributes = [
-        AsyncAttribute(
-          cancellableValueTask { return { name = "class"; value = "foo" } }
-        )
-        AsyncAttribute(
-          cancellableValueTask { return { name = "id"; value = "bar" } }
-        )
-      ]
-      children = []
+      attributes =
+        LinkedList [
+          AsyncAttribute(
+            cancellableValueTask { return { name = "class"; value = "foo" } }
+          )
+          AsyncAttribute(
+            cancellableValueTask { return { name = "id"; value = "bar" } }
+          )
+        ]
+      children = LinkedList()
     }
 
   let expected = "<div id=\"bar\" class=\"foo\"></div>"
@@ -163,10 +166,12 @@ let ``It should render an element with an async attribute``() = taskUnit {
 [<Fact>]
 let ``It should render a mix of sync/async nodes``() = taskUnit {
   let node =
-    Fragment [
-      AsyncNode(cancellableValueTask { return Text "Hello, " })
-      Text "world!"
-    ]
+    Fragment(
+      LinkedList [
+        AsyncNode(cancellableValueTask { return Text "Hello, " })
+        Text "world!"
+      ]
+    )
 
   let expected = "Hello, world!"
 
@@ -177,18 +182,21 @@ let ``It should render a mix of sync/async nodes``() = taskUnit {
 [<Fact>]
 let ``It should render a mix of sync/async nodes with attributes``() = taskUnit {
   let node =
-    Fragment [
-      AsyncNode(cancellableValueTask { return Text "Hello, " })
-      Element {
-        tag = "div"
-        attributes = [
-          Attribute { name = "class"; value = "foo" }
-          Attribute { name = "id"; value = "bar" }
-        ]
-        children = []
-      }
-      Text "world!"
-    ]
+    Fragment(
+      LinkedList [
+        AsyncNode(cancellableValueTask { return Text "Hello, " })
+        Element {
+          tag = "div"
+          attributes =
+            LinkedList [
+              Attribute { name = "class"; value = "foo" }
+              Attribute { name = "id"; value = "bar" }
+            ]
+          children = LinkedList()
+        }
+        Text "world!"
+      ]
+    )
 
   let expected = "Hello, <div id=\"bar\" class=\"foo\"></div>world!"
 
@@ -199,22 +207,27 @@ let ``It should render a mix of sync/async nodes with attributes``() = taskUnit 
 [<Fact>]
 let ``It should render a mix of sync/async nodes with async attributes``() = taskUnit {
   let node =
-    Fragment [
-      AsyncNode(cancellableValueTask { return Text "Hello, " })
-      Element {
-        tag = "div"
-        attributes = [
-          AsyncAttribute(
-            cancellableValueTask { return { name = "class"; value = "foo" } }
-          )
-          AsyncAttribute(
-            cancellableValueTask { return { name = "id"; value = "bar" } }
-          )
-        ]
-        children = []
-      }
-      Text "world!"
-    ]
+    Fragment(
+      LinkedList [
+        AsyncNode(cancellableValueTask { return Text "Hello, " })
+        Element {
+          tag = "div"
+          attributes =
+            LinkedList [
+              AsyncAttribute(
+                cancellableValueTask {
+                  return { name = "class"; value = "foo" }
+                }
+              )
+              AsyncAttribute(
+                cancellableValueTask { return { name = "id"; value = "bar" } }
+              )
+            ]
+          children = LinkedList()
+        }
+        Text "world!"
+      ]
+    )
 
   let expected = "Hello, <div id=\"bar\" class=\"foo\"></div>world!"
 
@@ -228,23 +241,29 @@ let ``It should render a mix of sync/async nodes with async attributes and async
   =
   taskUnit {
     let node =
-      Fragment [
-        AsyncNode(cancellableValueTask { return Text "Hello, " })
-        Element {
-          tag = "div"
-          attributes = [
-            AsyncAttribute(
-              cancellableValueTask { return { name = "class"; value = "foo" } }
-            )
-            AsyncAttribute(
-              cancellableValueTask { return { name = "id"; value = "bar" } }
-            )
-          ]
-          children = [
-            AsyncNode(cancellableValueTask { return Text "world!" })
-          ]
-        }
-      ]
+      Fragment(
+        LinkedList [
+          AsyncNode(cancellableValueTask { return Text "Hello, " })
+          Element {
+            tag = "div"
+            attributes =
+              LinkedList [
+                AsyncAttribute(
+                  cancellableValueTask {
+                    return { name = "class"; value = "foo" }
+                  }
+                )
+                AsyncAttribute(
+                  cancellableValueTask { return { name = "id"; value = "bar" } }
+                )
+              ]
+            children =
+              LinkedList [
+                AsyncNode(cancellableValueTask { return Text "world!" })
+              ]
+          }
+        ]
+      )
 
     let expected = "Hello, <div id=\"bar\" class=\"foo\">world!</div>"
 
@@ -258,24 +277,30 @@ let ``It should render a mix of sync/async nodes with async attributes and async
   =
   taskUnit {
     let node =
-      Fragment [
-        AsyncNode(cancellableValueTask { return Text "Hello, " })
-        Element {
-          tag = "div"
-          attributes = [
-            AsyncAttribute(
-              cancellableValueTask { return { name = "class"; value = "foo" } }
-            )
-            AsyncAttribute(
-              cancellableValueTask { return { name = "id"; value = "bar" } }
-            )
-          ]
-          children = [
-            AsyncNode(cancellableValueTask { return Text "world!" })
-          ]
-        }
-        AsyncNode(cancellableValueTask { return Text "!" })
-      ]
+      Fragment(
+        LinkedList [
+          AsyncNode(cancellableValueTask { return Text "Hello, " })
+          Element {
+            tag = "div"
+            attributes =
+              LinkedList [
+                AsyncAttribute(
+                  cancellableValueTask {
+                    return { name = "class"; value = "foo" }
+                  }
+                )
+                AsyncAttribute(
+                  cancellableValueTask { return { name = "id"; value = "bar" } }
+                )
+              ]
+            children =
+              LinkedList [
+                AsyncNode(cancellableValueTask { return Text "world!" })
+              ]
+          }
+          AsyncNode(cancellableValueTask { return Text "!" })
+        ]
+      )
 
     let expected = "Hello, <div id=\"bar\" class=\"foo\">world!</div>!"
 
@@ -289,30 +314,36 @@ let ``It should render a mix of sync/async nodes with async attributes and async
   =
   taskUnit {
     let node =
-      Fragment [
-        AsyncNode(cancellableValueTask { return Text "Hello, " })
-        Element {
-          tag = "div"
-          attributes = [
-            AsyncAttribute(
-              cancellableValueTask { return { name = "class"; value = "foo" } }
-            )
-            AsyncAttribute(
-              cancellableValueTask { return { name = "id"; value = "bar" } }
-            )
-          ]
-          children = [
-            AsyncNode(cancellableValueTask { return Text "world!" })
-          ]
-        }
-        AsyncNode(cancellableValueTask { return Text "!" })
-        AsyncSeqNode(
-          taskSeq {
-            Text " "
-            Text "How are you?"
+      Fragment(
+        LinkedList [
+          AsyncNode(cancellableValueTask { return Text "Hello, " })
+          Element {
+            tag = "div"
+            attributes =
+              LinkedList [
+                AsyncAttribute(
+                  cancellableValueTask {
+                    return { name = "class"; value = "foo" }
+                  }
+                )
+                AsyncAttribute(
+                  cancellableValueTask { return { name = "id"; value = "bar" } }
+                )
+              ]
+            children =
+              LinkedList [
+                AsyncNode(cancellableValueTask { return Text "world!" })
+              ]
           }
-        )
-      ]
+          AsyncNode(cancellableValueTask { return Text "!" })
+          AsyncSeqNode(
+            taskSeq {
+              Text " "
+              Text "How are you?"
+            }
+          )
+        ]
+      )
 
     let expected =
       "Hello, <div id=\"bar\" class=\"foo\">world!</div>! How are you?"
@@ -327,31 +358,37 @@ let ``It should render a mix of sync/async nodes with async attributes and async
   =
   taskUnit {
     let node =
-      Fragment [
-        AsyncNode(cancellableValueTask { return Text "Hello, " })
-        Element {
-          tag = "div"
-          attributes = [
-            AsyncAttribute(
-              cancellableValueTask { return { name = "class"; value = "foo" } }
-            )
-            AsyncAttribute(
-              cancellableValueTask { return { name = "id"; value = "bar" } }
-            )
-          ]
-          children = [
-            AsyncNode(cancellableValueTask { return Text "world!" })
-          ]
-        }
-        AsyncNode(cancellableValueTask { return Text "!" })
-        AsyncSeqNode(
-          taskSeq {
-            Text " "
-            Text "How are you?"
+      Fragment(
+        LinkedList [
+          AsyncNode(cancellableValueTask { return Text "Hello, " })
+          Element {
+            tag = "div"
+            attributes =
+              LinkedList [
+                AsyncAttribute(
+                  cancellableValueTask {
+                    return { name = "class"; value = "foo" }
+                  }
+                )
+                AsyncAttribute(
+                  cancellableValueTask { return { name = "id"; value = "bar" } }
+                )
+              ]
+            children =
+              LinkedList [
+                AsyncNode(cancellableValueTask { return Text "world!" })
+              ]
           }
-        )
-        AsyncNode(cancellableValueTask { return Text "I'm fine, thanks!" })
-      ]
+          AsyncNode(cancellableValueTask { return Text "!" })
+          AsyncSeqNode(
+            taskSeq {
+              Text " "
+              Text "How are you?"
+            }
+          )
+          AsyncNode(cancellableValueTask { return Text "I'm fine, thanks!" })
+        ]
+      )
 
     let expected =
       "Hello, <div id=\"bar\" class=\"foo\">world!</div>! How are you?I&#39;m fine, thanks!"
@@ -366,8 +403,8 @@ let ``Rendering childless nodes should not write the end tag``() = taskUnit {
   let node =
     Element {
       tag = "input"
-      attributes = []
-      children = []
+      attributes = LinkedList()
+      children = LinkedList()
     }
 
   let expected = "<input>"
@@ -379,24 +416,28 @@ let ``Rendering childless nodes should not write the end tag``() = taskUnit {
 [<Fact>]
 let ``Childless nodes can be added to elements and fragments``() = taskUnit {
   let node =
-    Fragment [
-      Element {
-        tag = "div"
-        attributes = []
-        children = [
-          Element {
-            tag = "source"
-            attributes = [ Attribute { name = "src"; value = "foo" } ]
-            children = []
-          }
-        ]
-      }
-      Element {
-        tag = "input"
-        attributes = []
-        children = []
-      }
-    ]
+    Fragment(
+      LinkedList [
+        Element {
+          tag = "div"
+          attributes = LinkedList()
+          children =
+            LinkedList [
+              Element {
+                tag = "source"
+                attributes =
+                  LinkedList [ Attribute { name = "src"; value = "foo" } ]
+                children = LinkedList()
+              }
+            ]
+        }
+        Element {
+          tag = "input"
+          attributes = LinkedList()
+          children = LinkedList()
+        }
+      ]
+    )
 
   let expected = "<div><source src=\"foo\"></div><input>"
 


### PR DESCRIPTION
This PR changes a few core things, mainly removes the usage of F# lists in exchange of BCL's Linked list.

Our actual usage is to add items at the end of the list and then when rendering traversing the list in reverse both operations were not a great fit for the F# list.

For DSL consumers this is not a breaking change as the API surface stayed the same.

For Core Type Consumers (e.g. folks building a DSL or similar use case) the breaking change resides in switching to liked list rather than F# list